### PR TITLE
Create Temperature accessory based on IR sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ By default, Sector alarm provides three modes (armed, partial armed and disarmed
 There are quite a few things that could be added to this.
 
 * Modularize. Refactor the code to be a platform rather than an accessory. Thus enabling separation between different possible accessories to the alarm system.
-* Support for temperature sensors.
 * Make it possible to configure different states and behaviours to state changes.
 * Clean up the code. 
 
@@ -36,6 +35,22 @@ Below is a configuration example snipped that should be inserted into your exist
             "polling": false,                  
             "pollInterval": 60000,             
             "name": "Home security"
+        },
+        {
+            "accessory": "Sector-SecuritySystemSensor",
+            "email": "myemail@someplace.com",
+            "password": "SuperSecurePassword",
+            "siteId": "111111",
+            "name": "Thermometer Livingroom",
+            "sensorId": "12345678901"
+        },
+        {
+            "accessory": "Sector-SecuritySystemSensor",
+            "email": "myemail@someplace.com",
+            "password": "SuperSecurePassword",
+            "siteId": "111111",
+            "name": "Termometer Basement",
+            "sensorId": "12345678902"
         }
     ]
 }


### PR DESCRIPTION
As seen in the `sectoralarm` package API (and Sector Alaram app), you can get temperatures via the IR/motion-sensors.

This PR makes that information available through a new kind of accessory `Sector-SecuritySystemSensor`.

You then have to add one instance of this accessory for each sensor you want to add.

This may seem a bit cumbersome to configure, but there are a few technical reasons for doing like that:

* bundling several services together in one accessory forces all these services to be placed in the same room in HomeKit (or the "Home" app), so you can't have the alarm in your Entry-hall, and the thermometer in living-room.
* you can't have several services of the same type (temperature-service) within the same accessory, so if you want to represent more than one thermometer, more than one entry is required anyway.

The resulting config looks something like this:

````json
  "accessories": [
        {
            "accessory": "Sector-SecuritySystem",
            "email": "--redacted--",
            "password": "--redacted--",
            "siteId": "--redacted--",
            "code": "--redacted--",
            "pollInterval": 60000,
            "name": "Sector Alarm"
        },
        {
            "accessory": "Sector-SecuritySystemSensor",
            "email": "--redacted--",
            "password": "--redacted--",
            "siteId": "--redacted--",
            "name": "Termometer Stue",
            "sensorId": "12345678901"
        },
        {
            "accessory": "Sector-SecuritySystemSensor",
            "email": "--redacted--",
            "password": "--redacted--",
            "siteId": "--redacted--",
            "name": "Termometer TV-Stue",
            "sensorId": "12345678902"
        }
````

If these changes are OK, maybe we should consider updating the README too.